### PR TITLE
Change CPUs accounting system

### DIFF
--- a/pkg/power/power.go
+++ b/pkg/power/power.go
@@ -2,12 +2,14 @@ package power
 
 import (
 	"fmt"
-	"github.com/go-logr/logr"
-	"github.com/hashicorp/go-multierror"
 	"os"
+	"path"
 	"runtime"
 	"strconv"
 	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/hashicorp/go-multierror"
 )
 
 var basePath = "/sys/devices/system/cpu"
@@ -133,7 +135,32 @@ func CreateInstance(hostName string) (Host, error) {
 
 // getNumberOfCpus defined as var so can be mocked by the unit test
 var getNumberOfCpus = func() uint {
-	return uint(runtime.NumCPU())
+	// First, try to get CPUs from sysfs. If the sysfs isn't available
+	// return Number of CPUs from runtime
+	cpusAvailable, err := readStringFromFile(path.Join(basePath, "online"))
+	if err != nil {
+		return uint(runtime.NumCPU())
+	}
+
+	// Delete \n character and split the string to get
+	// first and last element
+	cpusAvailable = strings.Replace(cpusAvailable, "\n", "", -1)
+	cpuSlice := strings.Split(cpusAvailable, "-")
+	if len(cpuSlice) < 2 {
+		return uint(runtime.NumCPU())
+	}
+
+	// Calculate number of CPUs, if an error occurs
+	// return the number of CPUs from runtime
+	firstElement, err := strconv.Atoi(cpuSlice[0])
+	if err != nil {
+		return uint(runtime.NumCPU())
+	}
+	secondElement, err := strconv.Atoi(cpuSlice[1])
+	if err != nil {
+		return uint(runtime.NumCPU())
+	}
+	return uint((secondElement - firstElement) + 1)
 }
 
 // reads a file from a path, parses contents as an int a returns the value


### PR DESCRIPTION
This commit aims to change the accounting system of CPUs. In some cases, the number of CPUs obtained through the runtime library function is slightly less than the actual/real number of CPUs.

This change introduces reading the number of CPUs online through sysfs (/sys/devices/system/cpu/online).

Signed-off-by: Eduardo Alberti <eduardo.alberti@windriver.com>
Co-authored by: Pedro de Souza Silva <pedro.desouzasilva@windriver.com>