### PR TITLE
Introduce pool level mutex for thread safety and corresponding tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/intel/power-optimization-library
 
-go 1.20
+go 1.21
 
 require (
 	github.com/go-logr/logr v1.2.4

--- a/pkg/power/c_states.go
+++ b/pkg/power/c_states.go
@@ -43,7 +43,7 @@ func initCStates() featureStatus {
 	driver = strings.TrimSuffix(driver, "\n")
 	feature.driver = driver
 	if err != nil {
-		feature.err = fmt.Errorf("failed to determine driver")
+		feature.err = fmt.Errorf("failed to determine driver: %w", err)
 		return feature
 	}
 	if !isSupportedCStatesDriver(driver) {

--- a/pkg/power/host.go
+++ b/pkg/power/host.go
@@ -2,6 +2,7 @@ package power
 
 import (
 	"fmt"
+	"sync"
 )
 
 // The hostImpl is the backing object of Host interface
@@ -45,13 +46,15 @@ func initHost(nodeName string) (Host, error) {
 	host.featureStates = &featureList
 	// create predefined pools
 	host.reservedPool = &reservedPoolType{poolImpl{
-		name: reservedPoolName,
-		host: host,
+		name:  reservedPoolName,
+		mutex: &sync.Mutex{},
+		host:  host,
 	}}
 	host.sharedPool = &sharedPoolType{poolImpl{
-		name: sharedPoolName,
-		cpus: CpuList{},
-		host: host,
+		name:  sharedPoolName,
+		cpus:  CpuList{},
+		mutex: &sync.Mutex{},
+		host:  host,
 	}}
 
 	topology, err := discoverTopology()
@@ -92,9 +95,10 @@ func (host *hostImpl) AddExclusivePool(poolName string) (Pool, error) {
 		return host.exclusivePools[i], fmt.Errorf("pool with name %s already exists", poolName)
 	}
 	var pool Pool = &exclusivePoolType{poolImpl{
-		name: poolName,
-		cpus: make([]Cpu, 0),
-		host: host,
+		name:  poolName,
+		mutex: &sync.Mutex{},
+		cpus:  make([]Cpu, 0),
+		host:  host,
 	}}
 
 	host.exclusivePools.add(pool)

--- a/pkg/power/integration_test.go
+++ b/pkg/power/integration_test.go
@@ -1,0 +1,118 @@
+// this file contains integration tests pof the power library
+package power
+
+import (
+	"errors"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"sync"
+	"testing"
+	"time"
+)
+
+// this test checks for potential race condition where one go routine moves cpus to a pool and another changes a power
+// profile of the target pool
+func TestConcurrentMoveCpusSetProfile(t *testing.T) {
+	const count = 5
+	for i := 0; i < count; i++ {
+		doConcurrentMoveCPUSetProfile(t)
+	}
+}
+
+func doConcurrentMoveCPUSetProfile(t *testing.T) {
+	const numCpus = 88
+	cpuConfig := map[string]string{
+		"min":                 "111",
+		"max":                 "999",
+		"driver":              "intel_pstate",
+		"available_governors": "performance",
+		"epp":                 "performance",
+	}
+	cpuConfigAll := map[string]map[string]string{}
+
+	cpuTopologyMap := map[string]map[string]string{}
+	for i := 0; i < numCpus; i++ {
+		cpuConfigAll[fmt.Sprint("cpu", i)] = cpuConfig
+		// for this test we don't care about topology, so we just emulate 1 pkg, 1 die, numCpus cores, no hyperthreading
+		cpuTopologyMap[fmt.Sprint("cpu", i)] = map[string]string{
+			"pkg":  "0",
+			"die":  "0",
+			"core": fmt.Sprint(i),
+		}
+	}
+	defer setupCpuCStatesTests(map[string]map[string]map[string]string{})()
+	defer setupUncoreTests(map[string]map[string]string{}, "")()
+	defer setupCpuScalingTests(cpuConfigAll)()
+	defer setupTopologyTest(cpuTopologyMap)()
+
+	instance, err := CreateInstance("host")
+
+	assert.ErrorContainsf(t, err, "failed to determine driver", "expecting c-states feature error")
+	assert.ErrorContainsf(t, err, "intel_uncore_frequency not loaded", "expecting uncore feature error")
+	assert.NotNil(t, instance)
+
+	assert.Len(t, *instance.GetAllCpus(), numCpus)
+	assert.ElementsMatch(t, *instance.GetReservedPool().Cpus(), *instance.GetAllCpus())
+	assert.Empty(t, *instance.GetSharedPool().Cpus())
+
+	profile, err := NewPowerProfile("pwr", 100, 1000, "performance", "performance")
+	assert.NoError(t, err)
+
+	wg := sync.WaitGroup{}
+
+	moveCoresFunc := func() {
+		defer wg.Done()
+		// move all cores to shared pool
+		assert.NoError(t, instance.GetSharedPool().MoveCpus(*instance.GetAllCpus()))
+	}
+	setPowerProfileFunc := func() {
+		defer wg.Done()
+		time.Sleep(5 * time.Millisecond)
+		// set power profile on shared pool
+		assert.NoError(t, instance.GetSharedPool().SetPowerProfile(profile))
+	}
+
+	wg.Add(2)
+	go moveCoresFunc()
+	go setPowerProfileFunc()
+	wg.Wait()
+
+	assert.Equal(t, profile, instance.GetSharedPool().GetPowerProfile())
+	assert.ElementsMatch(t, *instance.GetAllCpus(), *instance.GetSharedPool().Cpus())
+	for i := uint(0); i < numCpus; i++ {
+		assert.NoError(t, verifyPowerProfile(i, profile), "cpuid", i)
+	}
+}
+
+// verifies that the cpu is configured correctly
+// checking is done relative to basePath
+func verifyPowerProfile(cpuId uint, profile Profile) error {
+	var allerrs []error
+	var err error
+
+	governor, err := readCpuStringProperty(cpuId, scalingGovFile)
+	allerrs = append(allerrs, err)
+	if governor != profile.Governor() {
+		allerrs = append(allerrs, fmt.Errorf("governor mismatch expected : %s, current %s", profile.Governor(), governor))
+	}
+
+	if profile.Epp() != "" {
+		epp, err := readCpuStringProperty(cpuId, eppFile)
+		allerrs = append(allerrs, err)
+		if governor != profile.Epp() {
+			allerrs = append(allerrs, fmt.Errorf("epp mismatch expected : %s, current %s", profile.Epp(), epp))
+		}
+	}
+
+	maxFreq, err := readCpuUintProperty(cpuId, scalingMaxFile)
+	allerrs = append(allerrs, err)
+	if maxFreq != profile.MaxFreq() {
+		allerrs = append(allerrs, fmt.Errorf("maxFreq mismatch expected %d, current %d", profile.MaxFreq(), maxFreq))
+	}
+	minFreq, err := readCpuUintProperty(cpuId, scalingMinFile)
+	allerrs = append(allerrs, err)
+	if minFreq != profile.MinFreq() {
+		allerrs = append(allerrs, fmt.Errorf("minFreq mismatch expected %d, current %d", profile.MinFreq(), minFreq))
+	}
+	return errors.Join(allerrs...)
+}

--- a/pkg/power/power.go
+++ b/pkg/power/power.go
@@ -20,7 +20,7 @@ const (
 	sharedPoolName   = "sharedPool"
 	reservedPoolName = "reservedPool"
 
-	FreqencyScalingFeature featureID = iota
+	FrequencyScalingFeature featureID = iota
 	EPPFeature
 	CStatesFeature
 	UncoreFeature
@@ -29,7 +29,7 @@ const (
 type LibConfig struct {
 	CpuPath    string
 	ModulePath string
-	Cores uint
+	Cores      uint
 }
 
 // initialized with null logger, can be set to proper logger with SetLogger
@@ -41,7 +41,7 @@ var featureList FeatureSet = map[featureID]*featureStatus{
 		err:      uninitialisedErr,
 		initFunc: initEpp,
 	},
-	FreqencyScalingFeature: {
+	FrequencyScalingFeature: {
 		err:      uninitialisedErr,
 		initFunc: initScalingDriver,
 	},
@@ -150,7 +150,7 @@ func CreateInstanceWithConf(hostname string, conf LibConfig) (Host, error) {
 	if conf.ModulePath != "" {
 		kernelModulesFilePath = conf.ModulePath
 	}
-	getNumberOfCpus = func () uint { return conf.Cores}
+	getNumberOfCpus = func() uint { return conf.Cores }
 	return CreateInstance(hostname)
 }
 

--- a/pkg/power/power_profile.go
+++ b/pkg/power/power_profile.go
@@ -28,8 +28,8 @@ var availableGovs []string
 
 // NewPowerProfile creates a power profile,
 func NewPowerProfile(name string, minFreq uint, maxFreq uint, governor string, epp string) (Profile, error) {
-	if !featureList.isFeatureIdSupported(FreqencyScalingFeature) {
-		return nil, featureList.getFeatureIdError(FreqencyScalingFeature)
+	if !featureList.isFeatureIdSupported(FrequencyScalingFeature) {
+		return nil, featureList.getFeatureIdError(FrequencyScalingFeature)
 	}
 
 	if minFreq > maxFreq {

--- a/pkg/power/power_profile_test.go
+++ b/pkg/power/power_profile_test.go
@@ -13,9 +13,9 @@ func TestNewProfile(t *testing.T) {
 
 	assert.ErrorIs(t, err, uninitialisedErr)
 
-	featureList[FreqencyScalingFeature].err = nil
+	featureList[FrequencyScalingFeature].err = nil
 	featureList[EPPFeature].err = nil
-	defer func() { featureList[FreqencyScalingFeature].err = uninitialisedErr }()
+	defer func() { featureList[FrequencyScalingFeature].err = uninitialisedErr }()
 	defer func() { featureList[EPPFeature].err = uninitialisedErr }()
 
 	profile, err = NewPowerProfile("name", 0, 100, cpuPolicyPowersave, "epp")

--- a/pkg/power/power_test.go
+++ b/pkg/power/power_test.go
@@ -143,13 +143,13 @@ func Fuzz_library(f *testing.F) {
 		"package_01_die_00": uncoreFreqs,
 	}
 	cpuFreqs := map[string]string{
-		"max":     "123",
-		"min":     "100",
-		"epp":     "some",
-		"driver":  "intel_pstate",
+		"max":                 "123",
+		"min":                 "100",
+		"epp":                 "some",
+		"driver":              "intel_pstate",
 		"available_governors": "conservative ondemand userspace powersave",
-		"package": "0",
-		"die":     "0",
+		"package":             "0",
+		"die":                 "0",
 	}
 	cpuFreqsFiles := map[string]map[string]string{
 		"cpu0": cpuFreqs,
@@ -169,7 +169,7 @@ func Fuzz_library(f *testing.F) {
 	defer teardownUncore()
 	governorList := []string{"powersave", "performance"}
 	eppList := []string{"power", "performance", "balance-power", "balance-performance"}
-	f.Add("node1","performance",uint(250000),uint(120000),uint(5),uint(10))
+	f.Add("node1", "performance", uint(250000), uint(120000), uint(5), uint(10))
 	fuzzTarget := func(t *testing.T, nodeName string, poolName string, value1 uint, value2 uint, governorSeed uint, eppSeed uint) {
 		basePath = "testing/cpus"
 		getNumberOfCpus = func() uint { return 8 }
@@ -249,7 +249,7 @@ func Fuzz_library(f *testing.F) {
 		if err != nil {
 			t.Error("could not set die uncore", err)
 		}
-		
+
 	}
 	f.Fuzz(fuzzTarget)
 

--- a/pkg/power/scaling_driver.go
+++ b/pkg/power/scaling_driver.go
@@ -91,7 +91,7 @@ func initAvailableGovernors() ([]string, error) {
 	}
 	return strings.Split(govs, " "), nil
 }
-func GetAvailableGovernors() []string{
+func GetAvailableGovernors() []string {
 	return availableGovs
 }
 func generateDefaultProfile() error {
@@ -120,7 +120,7 @@ func generateDefaultProfile() error {
 }
 
 func (cpu *cpuImpl) updateFrequencies() error {
-	if !IsFeatureSupported(FreqencyScalingFeature) {
+	if !IsFeatureSupported(FrequencyScalingFeature) {
 		return nil
 	}
 	if cpu.pool.GetPowerProfile() != nil {

--- a/pkg/power/scaling_driver_test.go
+++ b/pkg/power/scaling_driver_test.go
@@ -57,17 +57,15 @@ func TestPreChecksScalingDriver(t *testing.T) {
 	teardown()
 	defer setupCpuScalingTests(map[string]map[string]string{
 		"cpu0": {
-			"driver": "acpi-cpufreq",
+			"driver":              "acpi-cpufreq",
 			"available_governors": "powersave",
-			"max": "3700",
-			"min": "3200",
+			"max":                 "3700",
+			"min":                 "3200",
 		},
 	})()
 	acpi := initScalingDriver()
 	assert.Equal(t, "acpi-cpufreq", acpi.driver)
 	assert.NoError(t, acpi.err)
-
-
 }
 
 func TestCoreImpl_updateFreqValues(t *testing.T) {


### PR DESCRIPTION
This PR will also:
- address race-condition issue in Checkmarx scan
- bump go version to 1.21 to keep library in sync with manager